### PR TITLE
IOTP-2905 Add logging for expired PUBLISH and PUBREL messages

### DIFF
--- a/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
@@ -580,7 +580,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
             int qos0Bytes = 0;
             while (qos0MessagesFound < packetIds.length() && bytesLimit > qos0Bytes) {
                 final PUBLISH qos0Publish = pollQos0Message(key, bucketIndex);
-                if (!PublishUtil.checkExpiry(qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
+                if (!PublishUtil.checkExpiry(qos0Publish)) {
                     publishes.add(qos0Publish);
                     qos0MessagesFound++;
                     qos0Bytes += qos0Publish.getEstimatedSizeInMemory();
@@ -606,7 +606,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
                 iterateQueue(cursor, key, true, () -> {
                     final ByteIterable serializedValue = cursor.getValue();
                     final PUBLISH publish = (PUBLISH) serializer.deserializeValue(serializedValue);
-                    if (PublishUtil.checkExpiry(publish.getTimestamp(), publish.getMessageExpiryInterval())) {
+                    if (PublishUtil.checkExpiry(publish)) {
                         cursor.deleteCurrent();
                         payloadPersistence.decrementReferenceCounter(publish.getPublishId());
                         getOrPutQueueSize(key, bucketIndex).decrementAndGet();
@@ -634,8 +634,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
                     // Add a qos 0 message
                     if (!qos0Messages.isEmpty()) {
                         final PUBLISH qos0Publish = pollQos0Message(key, bucketIndex);
-                        if (!PublishUtil.checkExpiry(
-                                qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
+                        if (!PublishUtil.checkExpiry(qos0Publish)) {
                             publishes.add(qos0Publish);
                             messageCount[0]++;
                             bytes[0] += qos0Publish.getEstimatedSizeInMemory();
@@ -1009,7 +1008,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
         while (iterator.hasNext()) {
             final PublishWithRetained publishWithRetained = iterator.next();
             final PUBLISH qos0Message = publishWithRetained.publish;
-            if (PublishUtil.checkExpiry(qos0Message.getTimestamp(), qos0Message.getMessageExpiryInterval())) {
+            if (PublishUtil.checkExpiry(qos0Message)) {
                 getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                 increaseQos0MessagesMemory(qos0Message.getEstimatedSizeInMemory() * -1);
                 increaseClientQos0MessagesMemory(key, qos0Message.getEstimatedSizeInMemory() * -1);
@@ -1037,7 +1036,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
                         if (pubrel.getExpiryInterval() == null || pubrel.getPublishTimestamp() == null) {
                             return true;
                         }
-                        if (!PublishUtil.checkExpiry(pubrel.getPublishTimestamp(), pubrel.getExpiryInterval())) {
+                        if (!PublishUtil.checkExpiry(pubrel)) {
                             return true;
                         }
                         getOrPutQueueSize(key, bucketIndex).decrementAndGet();

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -294,7 +294,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                 continue;
             }
 
-            if (PublishUtil.checkExpiry(publishWithRetained.getTimestamp(), publishWithRetained.getMessageExpiryInterval())) {
+            if (PublishUtil.checkExpiry(publishWithRetained)) {
                 iterator.remove();
                 payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
                 if (publishWithRetained.retained) {
@@ -317,7 +317,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
             // poll a qos 0 message
             final PUBLISH qos0Publish = pollQos0Message(messages);
-            if ((qos0Publish != null) && !PublishUtil.checkExpiry(qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
+            if ((qos0Publish != null) && !PublishUtil.checkExpiry(qos0Publish)) {
                 publishes.add(qos0Publish);
                 messageCount++;
                 bytes += qos0Publish.getEstimatedSizeInMemory();
@@ -340,7 +340,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             if (qos0Publish == null) {
                 break;
             }
-            if (!PublishUtil.checkExpiry(qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
+            if (!PublishUtil.checkExpiry(qos0Publish)) {
                 publishes.add(qos0Publish);
                 qos0MessagesFound++;
                 qos0Bytes += qos0Publish.getEstimatedSizeInMemory();
@@ -806,7 +806,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         final Iterator<PublishWithRetained> iterator = messages.qos0Messages.iterator();
         while (iterator.hasNext()) {
             final PublishWithRetained publishWithRetained = iterator.next();
-            if (PublishUtil.checkExpiry(publishWithRetained.getTimestamp(), publishWithRetained.getMessageExpiryInterval())) {
+            if (PublishUtil.checkExpiry(publishWithRetained)) {
                 increaseQos0MessagesMemory(-publishWithRetained.getEstimatedSize());
                 increaseClientQos0MessagesMemory(messages, -publishWithRetained.getEstimatedSize());
                 increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
@@ -826,7 +826,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                 if (pubrel.getExpiryInterval() == null || pubrel.getPublishTimestamp() == null) {
                     continue;
                 }
-                if (!PublishUtil.checkExpiry(pubrel.getPublishTimestamp(), pubrel.getExpiryInterval())) {
+                if (!PublishUtil.checkExpiry(pubrel)) {
                     continue;
                 }
                 if (pubrel.retained) {

--- a/src/main/java/com/hivemq/util/PublishUtil.java
+++ b/src/main/java/com/hivemq/util/PublishUtil.java
@@ -31,7 +31,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author Silvio Giebl
  */
 public class PublishUtil {
-    private static final Logger log = getLogger(Validators.class);
+    private static final Logger log = getLogger(PublishUtil.class);
 
     /**
      * Returns the minimum QoS of both passed QoS

--- a/src/main/java/com/hivemq/util/PublishUtil.java
+++ b/src/main/java/com/hivemq/util/PublishUtil.java
@@ -19,6 +19,10 @@ import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.mqtt.message.pubrel.PUBREL;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Various utilities for dealing with Publishes or data from Publishes
@@ -27,6 +31,7 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
  * @author Silvio Giebl
  */
 public class PublishUtil {
+    private static final Logger log = getLogger(Validators.class);
 
     /**
      * Returns the minimum QoS of both passed QoS
@@ -47,7 +52,25 @@ public class PublishUtil {
      * @return whether the given PUBLISH is expired.
      */
     public static boolean checkExpiry(final @NotNull PUBLISH publish) {
-        return checkExpiry(publish.getTimestamp(), publish.getMessageExpiryInterval());
+        boolean isExpired = checkExpiry(publish.getTimestamp(), publish.getMessageExpiryInterval());
+        if (isExpired) {
+            log.warn("PUBLISH packet has expired: topic={}, timestamp={}, expiryInterval={}s, qos={}", publish.getTopic(), publish.getTimestamp(), publish.getMessageExpiryInterval(), publish.getQoS());
+        }
+        return isExpired;
+    }
+
+    /**
+     * Checks whether the given PUBREL is expired.
+     *
+     * @param pubrel the PUBREL to check.
+     * @return whether the given PUBREL is expired.
+     */
+    public static boolean checkExpiry(final @NotNull PUBREL pubrel) {
+        boolean isExpired = checkExpiry(pubrel.getPublishTimestamp(), pubrel.getExpiryInterval());
+        if (isExpired) {
+            log.warn("PUBREL packet has expired: packet identifier={}, timestamp={}, expiryInterval={}s, reason code={}", pubrel.getPacketIdentifier(), pubrel.getPublishTimestamp(), pubrel.getExpiryInterval(), pubrel.getReasonCode());
+        }
+        return isExpired;
     }
 
     /**


### PR DESCRIPTION
PUBLISH and PUBREL messages which expire during their lifecycle (i.e. while in queue, when getting polled from queue or before delivering to subscribers) will now display a corresponding log message. Retained messages are not affecrted by this change.